### PR TITLE
이벤트 처리 SharedFlow -> Channel 

### DIFF
--- a/.idea/appInsightsSettings.xml
+++ b/.idea/appInsightsSettings.xml
@@ -7,10 +7,10 @@
         <entry key="Android Vitals">
           <value>
             <InsightsFilterSettings>
-              <option name="failureTypes">
-                <list>
-                  <option value="ANR" />
-                </list>
+              <option name="connection">
+                <ConnectionSetting>
+                  <option name="appId" value="com.dkproject.space_out" />
+                </ConnectionSetting>
               </option>
               <option name="signal" value="SIGNAL_UNSPECIFIED" />
               <option name="timeIntervalDays" value="SEVEN_DAYS" />

--- a/domain/src/main/java/com/dkproject/domain/usecase/Guest/GetPostDataUseCase.kt
+++ b/domain/src/main/java/com/dkproject/domain/usecase/Guest/GetPostDataUseCase.kt
@@ -6,5 +6,6 @@ import com.dkproject.domain.repository.GuestRepository
 class GetPostDataUseCase(
     private val guestRepository: GuestRepository
 ) {
-    suspend operator fun invoke(postUid: String): Result<GuestPost> = guestRepository.getPostData(postUid = postUid)
+    suspend operator fun invoke(postUid: String): Result<GuestPost> =
+        guestRepository.getPostData(postUid = postUid)
 }

--- a/presentation/src/main/java/com/dkproject/presentation/navigation/GuestNavGraph.kt
+++ b/presentation/src/main/java/com/dkproject/presentation/navigation/GuestNavGraph.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavGraphBuilder
@@ -66,7 +67,7 @@ fun NavGraphBuilder.guestNavGraph(
         LaunchedEffect(guestPost) {
             viewModel.getPostInfo(guestPost)
         }
-        val uiState by viewModel.uiState.collectAsState()
+        val uiState by viewModel.uiState.collectAsStateWithLifecycle()
         GuestDetailScreen(
             uiState = uiState,
             uiEvent = viewModel.uiEvent,

--- a/presentation/src/main/java/com/dkproject/presentation/ui/screen/Chat/ChatScreen.kt
+++ b/presentation/src/main/java/com/dkproject/presentation/ui/screen/Chat/ChatScreen.kt
@@ -173,7 +173,7 @@ fun ChatList(
                 )
             }
         }
-        items(chatList.itemCount, key = { chatList[it]?.id ?: it }) {
+        items(chatList.itemCount, key = { chatList.peek(it)?.id ?: it }) {
             val chat = chatList[it] ?: return@items
             if (chat.sender == otherUserUid) {
                 OtherUserChat(

--- a/presentation/src/main/java/com/dkproject/presentation/ui/screen/Guest/GuestViewModel.kt
+++ b/presentation/src/main/java/com/dkproject/presentation/ui/screen/Guest/GuestViewModel.kt
@@ -75,7 +75,3 @@ data class GuestListUiState(
     val guestFilter: GuestFilterUiModel = GuestFilterUiModel(selectedDate = null),
     val isLoading: Boolean = false
 )
-
-sealed class GuestUiEvent {
-    data class ShowSnackbar(val message: String) : GuestUiEvent()
-}

--- a/presentation/src/main/java/com/dkproject/presentation/ui/screen/GuestDetail/GuestDetailScreen.kt
+++ b/presentation/src/main/java/com/dkproject/presentation/ui/screen/GuestDetail/GuestDetailScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -71,6 +70,7 @@ import com.dkproject.presentation.ui.component.button.DefaultButton
 import com.dkproject.presentation.ui.component.util.ErrorScreen
 import com.dkproject.presentation.ui.component.util.LoadingScreen
 import com.dkproject.presentation.ui.theme.AppTheme
+import com.dkproject.presentation.util.collectOnStarted
 import com.dkproject.presentation.util.GetUserStatusString
 import com.dkproject.presentation.util.guestPostDummy
 import com.naver.maps.geometry.LatLng
@@ -82,12 +82,12 @@ import com.naver.maps.map.compose.Marker
 import com.naver.maps.map.compose.MarkerState
 import com.naver.maps.map.compose.NaverMap
 import com.naver.maps.map.compose.rememberCameraPositionState
-import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.Flow
 
 @Composable
 fun GuestDetailScreen(
     uiState: PostDetailUiState,
-    uiEvent: SharedFlow<DetailUiEvent>,
+    uiEvent: Flow<DetailUiEvent>,
     snackbarHostState: SnackbarHostState,
     loseLoginInfo: () -> Unit = {},     // 로그인 정보 잃음
     navPopBackStack: () -> Unit = {},   // 뒤로가기
@@ -104,22 +104,20 @@ fun GuestDetailScreen(
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
-    LaunchedEffect(uiEvent) {
-        uiEvent.collect { event ->
-            when (event) {
-                DetailUiEvent.LoseLoginInfo -> {}
-                DetailUiEvent.ManageGuest -> navigateToMange()
-                DetailUiEvent.DeleteCompletedPost -> onDeleteBack()
-                is DetailUiEvent.ShowSnackbar -> snackbarHostState.showSnackbar(event.message)
-                is DetailUiEvent.NoSuchData -> {
-                    Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
-                    navPopBackStack()
-                }
-                is DetailUiEvent.NavigateChat -> {
-                    navigateToChat(event.chat)
-                }
-                DetailUiEvent.PopBackStack -> navPopBackStack()
+    uiEvent.collectOnStarted { event ->
+        when(event) {
+            DetailUiEvent.LoseLoginInfo -> {}
+            DetailUiEvent.ManageGuest -> navigateToMange()
+            DetailUiEvent.DeleteCompletedPost -> onDeleteBack()
+            is DetailUiEvent.ShowSnackbar -> snackbarHostState.showSnackbar(event.message)
+            is DetailUiEvent.NoSuchData -> {
+                Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
+                navPopBackStack()
             }
+            is DetailUiEvent.NavigateChat -> {
+                navigateToChat(event.chat)
+            }
+            DetailUiEvent.PopBackStack -> navPopBackStack()
         }
     }
     when (uiState.dataState) {

--- a/presentation/src/main/java/com/dkproject/presentation/ui/screen/GuestManage/GuestManageScreen.kt
+++ b/presentation/src/main/java/com/dkproject/presentation/ui/screen/GuestManage/GuestManageScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -63,13 +62,14 @@ import com.dkproject.presentation.ui.component.button.AcceptButton
 import com.dkproject.presentation.ui.component.button.RejectButton
 import com.dkproject.presentation.ui.component.util.ErrorScreen
 import com.dkproject.presentation.ui.component.util.LoadingScreen
+import com.dkproject.presentation.util.collectOnStarted
 import com.dkproject.presentation.util.getGuestManageStatusString
-import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.Flow
 
 @Composable
 fun GuestManageScreen(
     uiState: GuestManageUiState,
-    uiEvent: SharedFlow<GuestManageUiEvent>,
+    uiEvent: Flow<GuestManageUiEvent>,
     snackbarHostState: SnackbarHostState,
     onBackClick: () -> Unit,
     onAcceptClick: (String) -> Unit = {},
@@ -80,12 +80,10 @@ fun GuestManageScreen(
     val changeStatusItems = uiState.changeStatusItems
     val isRefreshLoading = uiState.isRefreshLoading
 
-    LaunchedEffect(uiEvent) {
-        uiEvent.collect { event ->
-            when (event) {
-                is GuestManageUiEvent.ShowMessage -> {
-                    snackbarHostState.showSnackbar(event.message)
-                }
+    uiEvent.collectOnStarted {
+        when (it) {
+            is GuestManageUiEvent.ShowMessage -> {
+                snackbarHostState.showSnackbar(it.message)
             }
         }
     }

--- a/presentation/src/main/java/com/dkproject/presentation/ui/screen/GuestManage/GuestManageViewModel.kt
+++ b/presentation/src/main/java/com/dkproject/presentation/ui/screen/GuestManage/GuestManageViewModel.kt
@@ -14,6 +14,7 @@ import com.dkproject.presentation.R
 import com.dkproject.presentation.di.ResourceProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -22,6 +23,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -37,8 +39,8 @@ class GuestManageViewModel @Inject constructor(
         MutableStateFlow(GuestManageUiState())
     val uiState: StateFlow<GuestManageUiState> = _uiState.asStateFlow()
 
-    private val _uiEvent = MutableSharedFlow<GuestManageUiEvent>()
-    val uiEvent = _uiEvent.asSharedFlow()
+    private val _uiEvent = Channel<GuestManageUiEvent>()
+    val uiEvent = _uiEvent.receiveAsFlow()
 
     fun getManageList(postId: String) {
         _uiState.update {
@@ -104,12 +106,12 @@ class GuestManageViewModel @Inject constructor(
     private suspend fun errorHandling(e: Throwable) {
         updateIsLoadingState(false)
         when (e) {
-            is DomainError.DocumentNotFound -> _uiEvent.emit(
+            is DomainError.DocumentNotFound -> _uiEvent.send(
                 GuestManageUiEvent.ShowMessage(
                     resourceProvider.getString(R.string.managenotfound)
                 )
             )
-            else -> _uiEvent.emit(GuestManageUiEvent.ShowMessage(resourceProvider.getString(R.string.failreject)))
+            else -> _uiEvent.send(GuestManageUiEvent.ShowMessage(resourceProvider.getString(R.string.failreject)))
         }
     }
 }

--- a/presentation/src/main/java/com/dkproject/presentation/ui/screen/GuestPost/GuestPostScreen.kt
+++ b/presentation/src/main/java/com/dkproject/presentation/ui/screen/GuestPost/GuestPostScreen.kt
@@ -36,6 +36,8 @@ import com.dkproject.presentation.R
 import com.dkproject.presentation.model.GuestPostUiModel
 import com.dkproject.presentation.model.Position
 import com.dkproject.presentation.ui.theme.AppTheme
+import com.dkproject.presentation.util.collectOnStarted
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.emptyFlow
@@ -45,7 +47,7 @@ import java.util.Date
 @Composable
 fun GuestPostScreen(
     uiState: GuestPostState,
-    uiEvent: SharedFlow<PostUiEvent>,
+    uiEvent: Flow<PostUiEvent>,
     snackbarHostState: SnackbarHostState,
     updateCurrentStep: (GuestPostStep) -> Unit = {},
     titleChange: (String) -> Unit = {},
@@ -62,13 +64,11 @@ fun GuestPostScreen(
     onBackClick: () -> Unit = {}
 ) {
 
-    LaunchedEffect(uiEvent) {
-        uiEvent.collect { event ->
-            when (event) {
-                is PostUiEvent.ShowSnackbar -> snackbarHostState.showSnackbar(message = event.message)
-                PostUiEvent.UploadComplete -> onUpload()
-                PostUiEvent.UpdateComplete -> onEdit()
-            }
+    uiEvent.collectOnStarted {
+        when (it) {
+            is PostUiEvent.ShowSnackbar -> snackbarHostState.showSnackbar(message = it.message)
+            PostUiEvent.UploadComplete -> onUpload()
+            PostUiEvent.UpdateComplete -> onEdit()
         }
     }
 

--- a/presentation/src/main/java/com/dkproject/presentation/ui/screen/Manage/ManageViewModel.kt
+++ b/presentation/src/main/java/com/dkproject/presentation/ui/screen/Manage/ManageViewModel.kt
@@ -13,6 +13,7 @@ import com.dkproject.presentation.model.toUiModel
 import com.google.firebase.auth.FirebaseAuth
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -21,6 +22,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -34,8 +36,8 @@ class ManageViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(ManageUiState())
     val uiState = _uiState.asStateFlow()
 
-    private val _uiEvent = MutableSharedFlow<ManageUiEvent>()
-    val uiEvent = _uiEvent.asSharedFlow()
+    private val _uiEvent = Channel<ManageUiEvent>()
+    val uiEvent = _uiEvent.receiveAsFlow()
 
     init {
         viewModelScope.launch {
@@ -74,7 +76,7 @@ class ManageViewModel @Inject constructor(
 
     private suspend fun getCurrentUserId(): String? {
         return auth.currentUser?.uid ?: run {
-            _uiEvent.emit(ManageUiEvent.LoseLoginInfo)
+            _uiEvent.send(ManageUiEvent.LoseLoginInfo)
             null
         }
     }

--- a/presentation/src/main/java/com/dkproject/presentation/ui/screen/login/GoogleSignInClient.kt
+++ b/presentation/src/main/java/com/dkproject/presentation/ui/screen/login/GoogleSignInClient.kt
@@ -84,6 +84,7 @@ class GoogleSignInClient @Inject constructor(
             try {
                 val tokenCredential = GoogleIdTokenCredential.createFrom(credential.data)
                 val authCredential = GoogleAuthProvider.getCredential(tokenCredential.idToken, null)
+                Log.d("googleSignIn", "signIn: ${tokenCredential.idToken}")
                 val authResult = firebaseAuth.signInWithCredential(authCredential).await()
                 return SignInResult.Success(authResult.user?.uid ?: "")
             } catch (e: GoogleIdTokenParsingException) {

--- a/presentation/src/main/java/com/dkproject/presentation/ui/screen/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/dkproject/presentation/ui/screen/login/LoginScreen.kt
@@ -27,6 +27,7 @@ import com.dkproject.presentation.ui.component.button.GoogleConfig
 import com.dkproject.presentation.ui.component.button.KakaoConfig
 import com.dkproject.presentation.ui.component.button.SocialButton
 import com.dkproject.presentation.ui.theme.AppTheme
+import com.dkproject.presentation.util.collectOnStarted
 
 @Composable
 fun LoginScreen(
@@ -36,16 +37,15 @@ fun LoginScreen(
     moveToSignUp: () -> Unit
 ) {
     val uiState by viewModel.uiState.collectAsState()
-    LaunchedEffect(viewModel.uiEvent) {
-        viewModel.uiEvent.collect { event ->
-            when(event) {
-                is LoginUiEvent.MoveToHome -> moveToHome()
-                is LoginUiEvent.MoveToSignUp -> moveToSignUp()
-                is LoginUiEvent.ShowSnackbar -> {
-                    snackbarHostState.showSnackbar(event.message)
-                }
+    viewModel.uiEvent.collectOnStarted { event ->
+        when(event) {
+            is LoginUiEvent.MoveToHome -> moveToHome()
+            is LoginUiEvent.MoveToSignUp -> moveToSignUp()
+            is LoginUiEvent.ShowSnackbar -> {
+                snackbarHostState.showSnackbar(event.message)
             }
         }
+
     }
 
     Box(modifier = Modifier.fillMaxSize()) {

--- a/presentation/src/main/java/com/dkproject/presentation/ui/screen/myPage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/dkproject/presentation/ui/screen/myPage/MyPageScreen.kt
@@ -65,6 +65,7 @@ import com.dkproject.presentation.ui.component.sheet.ChangeNicknameSheet
 import com.dkproject.presentation.ui.component.util.ErrorScreen
 import com.dkproject.presentation.ui.component.util.LoadingScreen
 import com.dkproject.presentation.ui.component.wheelpicker.IntWheelPicker
+import com.dkproject.presentation.util.collectOnStarted
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -81,24 +82,23 @@ fun MyPageScreen(
     var isEditWeight by remember { mutableStateOf(false) }
     val uiState by viewModel.uiState.collectAsState()
     val context = LocalContext.current
-    LaunchedEffect(viewModel.uiEvent) {
-        viewModel.uiEvent.collect { event ->
-            when (event) {
-                MyPageUiEvent.NavigateToLogin -> {
-                    moveToLogin()
-                }
+    viewModel.uiEvent.collectOnStarted { event ->
+        when (event) {
+            MyPageUiEvent.NavigateToLogin -> {
+                moveToLogin()
+            }
 
-                MyPageUiEvent.CompleteChangeNickname -> isEditNickname = false
-                is MyPageUiEvent.ShowToast -> {
-                    Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
-                }
+            MyPageUiEvent.CompleteChangeNickname -> isEditNickname = false
+            is MyPageUiEvent.ShowToast -> {
+                Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
+            }
 
-                is MyPageUiEvent.ShowSnackBar -> {
-                    snackbarHostState.showSnackbar(event.message)
-                }
+            is MyPageUiEvent.ShowSnackBar -> {
+                snackbarHostState.showSnackbar(event.message)
             }
         }
     }
+
     Box(modifier = modifier) {
         Column {
             TopAppBar(title = { Text(text = stringResource(R.string.myInfo)) })

--- a/presentation/src/main/java/com/dkproject/presentation/ui/screen/signUp/SignUpScreen.kt
+++ b/presentation/src/main/java/com/dkproject/presentation/ui/screen/signUp/SignUpScreen.kt
@@ -25,13 +25,15 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.dkproject.presentation.R
 import com.dkproject.presentation.model.Position
+import com.dkproject.presentation.util.collectOnStarted
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SignUpScreen(
     uiState: SignUpViewState,
-    uiEvent: SharedFlow<SignUpUiEvent>,
+    uiEvent: Flow<SignUpUiEvent>,
     snackbarHostState: SnackbarHostState,
     onBackClick: () -> Unit,
     onNextStep: () -> Unit,
@@ -44,22 +46,26 @@ fun SignUpScreen(
 ) {
     val progressValue by animateFloatAsState(targetValue = uiState.currentStep.progress, label = "")
 
-    LaunchedEffect(uiEvent) {
-        uiEvent.collect { event ->
-            when (event) {
-                is SignUpUiEvent.ShowSnackbar -> {
-                    snackbarHostState.showSnackbar(event.message)
-                }
-                is SignUpUiEvent.MoveToHome -> {
-                    moveToHome()
-                }
+    uiEvent.collectOnStarted { event ->
+        when (event) {
+            is SignUpUiEvent.ShowSnackbar -> {
+                snackbarHostState.showSnackbar(event.message)
+            }
+
+            is SignUpUiEvent.MoveToHome -> {
+                moveToHome()
             }
         }
     }
 
     Column(modifier = Modifier.fillMaxSize()) {
         CenterAlignedTopAppBar(
-            title = { Text(stringResource(uiState.currentStep.title), style = MaterialTheme.typography.titleMedium) },
+            title = {
+                Text(
+                    stringResource(uiState.currentStep.title),
+                    style = MaterialTheme.typography.titleMedium
+                )
+            },
             navigationIcon = {
                 IconButton(onClick = onBackClick) {
                     Icon(

--- a/presentation/src/main/java/com/dkproject/presentation/util/collectOnStarted.kt
+++ b/presentation/src/main/java/com/dkproject/presentation/util/collectOnStarted.kt
@@ -1,0 +1,22 @@
+package com.dkproject.presentation.util
+
+import android.util.Log
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.flow.Flow
+
+@Composable
+fun <T> Flow<T>.collectOnStarted(
+    action: suspend (T) -> Unit
+) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    LaunchedEffect(this, lifecycleOwner) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            Log.d("GuestDetailViewModel", "collectOnStarted")
+            collect { action(it) }
+        }
+    }
+}


### PR DESCRIPTION
# SharedFlow에서 Channel로
이벤트 처리 시 만족되어야 할 사항
1. 구독자가 없을 때 이벤트가 발생했어도, 다시 구독자가 생기면 해당 이벤트가 전달되어야 합니다. 사용자가 이벤트를 받기 전 홈버튼을 누르고 다시 돌아왔을 때 해당 이벤트를 전달 받을 수 있어야 합니다.
2. 이벤트가 소비되면(처리) 다시 처리되지 않아야 합니다. Configufation Change가 일어나도 이전에 소비된 이벤트는 더 이상 받을 필요가 없습니다.

1번에 대한 예시로 List에서 Item 클릭 -> 디테일 화면 이동로직에서 
디테일 화면에서 유저의 상태를 체크하고 상태에 따라 다른 뷰를 뿌려준다고 가정해보겠습니다.
서버가 아직 상태 체크중인데 유저가 홈 화면을 눌름(ON_STOP)
사용자가 다시 앱으로 돌아왔을 때 이벤트를 받지 못하는 문제 발생

## Channel
channel(비동기 데이터 스트림)은 위 사항들에 대해 만족
또한 `receiveAsFlow()` 함수를 통해 Flow로 전환이 가능하여 뷰쪽의 코드 변경 X
뷰모델의 이벤트 타입만 바꿔주면 됨

## Flow 확장함수 작성
lifecycle - aware 하게 이벤트를 수집해야 하므로 Compose에서 
LaunchedEffect 내에서 lifecycleOwner.lifecycle.repeatOnLifecycle를 매번 작성해야 하는 번거로움 발생
```kotlin
@Composable
fun <T> Flow<T>.collectOnStarted(
    action: suspend (T) -> Unit
) {
    val lifecycleOwner = LocalLifecycleOwner.current
    LaunchedEffect(this, lifecycleOwner) {
        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
            Log.d("GuestDetailViewModel", "collectOnStarted")
            collect { action(it) }
        }
    }
}
```
<br>
뷰쪽에서의 변경된 코드

```kotlin
 viewModel.uiEvent.collectOnStarted { event ->
        when (event) { event ->
            // 이벤트 처리
        }
    }

```

참고문헌
https://medium.com/prnd/viewmodel에서-더이상-eventflow를-사용하지-마세요-3974e8ddffed